### PR TITLE
feat: add reverse scroll direction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add `simple_ruler_picker` to your project's `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  simple_ruler_picker: ^0.1.0
+  simple_ruler_picker: ^0.1.1
 ```
 
 Or
@@ -70,24 +70,25 @@ SimpleRulerPicker(
 
 ## Properties
 
-| Property             | Type                | Default           | Description                                                                                            | Example                                   |
-| -------------------- | ------------------- | ----------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
-| `minValue`           | `int`               | 0                 | The minimum value that can be selected.                                                                | `minValue: 0`                             |
-| `maxValue`           | `int`               | 200               | The maximum value that can be selected.                                                                | `maxValue: 100`                           |
+| Property             | Type                | Default           | Description                                                                                       | Example                                   |
+|----------------------|---------------------|-------------------|---------------------------------------------------------------------------------------------------|-------------------------------------------|
+| `minValue`           | `int`               | 0                 | The minimum value that can be selected.                                                           | `minValue: 0`                             |
+| `maxValue`           | `int`               | 200               | The maximum value that can be selected.                                                           | `maxValue: 100`                           |
 | `initialValue`       | `int`               | 100               | The initial value displayed when the picker is first shown. Must be between `minValue` and `maxValue`. | `initialValue: 50`                        |
-| `scaleLabelSize`     | `double`            | `14`              | The size of the text for the scale labels.                                                             | `scaleLabelSize: 16`                      |
-| `scaleLabelWidth`    | `double`            | `40`              | The width of the text for the scale labels when axis is vertical.                                      | `scaleLabelWidth: 40`                     |
-| `scaleBottomPadding` | `double`            | `6`               | Padding below the scale labels, creating space between the labels and the bottom of the picker.        | `scaleBottomPadding: 8`                   |
-| `scaleItemWidth`     | `int`               | `10`              | The width of each scale item (i.e., the distance between the lines on the ruler).                      | `scaleItemWidth: 15`                      |
-| `onValueChanged`     | `ValueChanged<int>` | null              | Callback triggered whenever the selected value changes.                                                | `onValueChanged: (value) => print(value)` |
-| `longLineHeight`     | `double`            | `24`              | Height of the long lines in the ruler (typically for major units).                                     | `longLineHeight: 30`                      |
-| `shortLineHeight`    | `double`            | `12`              | Height of the short lines in the ruler (typically for minor units).                                    | `shortLineHeight: 15`                     |
-| `lineColor`          | `Color`             | `Colors.grey`     | Color of the ruler's lines (both long and short).                                                      | `lineColor: Colors.black`                 |
-| `selectedColor`      | `Color`             | `Colors.orange`   | Color of the selected item on the ruler.                                                               | `selectedColor: Colors.blue`              |
-| `labelColor`         | `Color`             | `Colors.grey`     | Color of the scale labels.                                                                             | `labelColor: Colors.black`                |
-| `lineStroke`         | `double`            | `2`               | The thickness (stroke width) of the ruler's lines.                                                     | `lineStroke: 3`                           |
-| `height`             | `double`            | `100`             | The overall height of the ruler picker.                                                                | `height: 120`                             |
-| `axis`               | `Axis`              | `Axis.horizontal` | The axis along which the picker scrolls.                                                               | `axis: Axis.horizontal`                   |
+| `scaleLabelSize`     | `double`            | `14`              | The size of the text for the scale labels.                                                        | `scaleLabelSize: 16`                      |
+| `scaleLabelWidth`    | `double`            | `40`              | The width of the text for the scale labels when axis is vertical.                                 | `scaleLabelWidth: 40`                     |
+| `scaleBottomPadding` | `double`            | `6`               | Padding below the scale labels, creating space between the labels and the bottom of the picker.   | `scaleBottomPadding: 8`                   |
+| `scaleItemWidth`     | `int`               | `10`              | The width of each scale item (i.e., the distance between the lines on the ruler).                 | `scaleItemWidth: 15`                      |
+| `onValueChanged`     | `ValueChanged<int>` | null              | Callback triggered whenever the selected value changes.                                           | `onValueChanged: (value) => print(value)` |
+| `longLineHeight`     | `double`            | `24`              | Height of the long lines in the ruler (typically for major units).                                | `longLineHeight: 30`                      |
+| `shortLineHeight`    | `double`            | `12`              | Height of the short lines in the ruler (typically for minor units).                               | `shortLineHeight: 15`                     |
+| `lineColor`          | `Color`             | `Colors.grey`     | Color of the ruler's lines (both long and short).                                                 | `lineColor: Colors.black`                 |
+| `selectedColor`      | `Color`             | `Colors.orange`   | Color of the selected item on the ruler.                                                          | `selectedColor: Colors.blue`              |
+| `labelColor`         | `Color`             | `Colors.grey`     | Color of the scale labels.                                                                        | `labelColor: Colors.black`                |
+| `lineStroke`         | `double`            | `2`               | The thickness (stroke width) of the ruler's lines.                                                | `lineStroke: 3`                           |
+| `height`             | `double`            | `100`             | The overall height of the ruler picker.                                                           | `height: 120`                             |
+| `axis`               | `Axis`              | `Axis.horizontal` | The axis along which the picker scrolls.                                                          | `axis: Axis.horizontal`                   |
+| `reverse`            | `bool`              | `false`           | Whether to reverse the scroll direction.                                                          | `reverse: true`                           |
 
 ## Additional information
 

--- a/lib/simple_ruler_picker.dart
+++ b/lib/simple_ruler_picker.dart
@@ -52,6 +52,9 @@ class SimpleRulerPicker extends StatefulWidget {
   /// The axis along which the picker scrolls.
   final Axis axis;
 
+  /// Whether to reverse the scroll direction.
+  final bool reverse;
+
   /// Creates a [SimpleRulerPicker] widget.
   ///
   /// The [minValue] must be less than or equal to [initialValue],
@@ -72,6 +75,7 @@ class SimpleRulerPicker extends StatefulWidget {
     this.selectedColor = Colors.orange,
     this.labelColor = Colors.grey,
     this.lineStroke = 2,
+    this.reverse = false,
     this.height = 100,
     this.axis = Axis.horizontal,
   }) : assert(
@@ -164,6 +168,7 @@ class _SimpleRulerPickerState extends State<SimpleRulerPicker> {
               onNotification: onNotification,
               child: LayoutBuilder(
                 builder: (context, constraints) => ListView.builder(
+                  reverse: widget.reverse,
                   padding: _isHorizontalAxis
                       ? EdgeInsets.only(
                           left: constraints.maxWidth / 2,


### PR DESCRIPTION
This commit introduces a new `reverse` property to the `SimpleRulerPicker` widget, allowing users to reverse the scroll direction.